### PR TITLE
Bugfix: User destroy with Turbo and search

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,9 +46,11 @@ class UsersController < ApplicationController
     respond_to do |format|
       if @user.trash
         format.html { redirect_to users_path, notice: "User was successfully trashed." }
+        format.turbo_stream
         format.json { head :no_content }
       else
         format.html { redirect_to users_path, alert: "User could not be trashed." }
+        format.turbo_stream { redirect_to users_path, alert: "User could not be trashed." }
         format.json { head :unprocessable_entity }
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,9 +29,13 @@ class User < ApplicationRecord
     "O-" => "negative_zero"
   }
 
-  scope :by_age, ->(from:, to:) { where(age: (from.to_i..to.to_i)) }
   MIN_AGE = 1
   MAX_AGE = 125
+  scope :by_age, lambda { |from: nil, to: nil|
+    from = from.presence || MIN_AGE
+    to = to.presence || MAX_AGE
+    where(age: (from.to_i..to.to_i))
+  }
 
   pg_search_scope :by_full_name_and_email,
                   against: %i[first_name last_name maiden_name email],

--- a/app/views/users/_user_row.html.erb
+++ b/app/views/users/_user_row.html.erb
@@ -6,15 +6,17 @@
   </td>
   <td>
     <div class="d-flex align-items-center gap-3">
+      <%= link_to user do %>
+        <div>
+          <% if user.image.present? %>
+            <%= image_tag(user.image, height: 45, width: 45, alt: user.name, class: "rounded") %>
+          <% else %>
+            <div class="rounded-circle user-row-default-picture"></div>
+          <% end %>
+        </div>
+      <% end %>
       <div>
-        <% if user.image.present? %>
-          <%= image_tag(user.image, height: 45, width: 45, alt: user.name, class: "rounded") %>
-        <% else %>
-          <div class="rounded-circle user-row-default-picture"></div>
-        <% end %>
-      </div>
-      <div>
-        <p class="fw-bold mb-1"><%= user.name %></p>
+        <%= link_to user.name, user, class: "link-dark fw-bold mb-1 text-decoration-none" %>
         <p class="text-muted mb-0"><%= user.email %></p>
       </div>
     </div>

--- a/app/views/users/addresses/show.html.erb
+++ b/app/views/users/addresses/show.html.erb
@@ -7,7 +7,7 @@
           <span>Back to Users</span>
         <% end %>
 
-        <%= button_to @user, method: :delete, class: "btn btn-danger btn-rounded btn-lg" do %>
+        <%= button_to @user, method: :delete,  data: { turbo: false },class: "btn btn-danger btn-rounded btn-lg" do %>
           <i class="bi bi-trash3-fill"></i>
           <span>Delete</span>
         <% end %>

--- a/app/views/users/banks/show.html.erb
+++ b/app/views/users/banks/show.html.erb
@@ -7,7 +7,7 @@
           <span>Back to Users</span>
         <% end %>
 
-        <%= button_to @user, method: :delete, class: "btn btn-danger btn-rounded btn-lg" do %>
+        <%= button_to @user, method: :delete,  data: { turbo: false },class: "btn btn-danger btn-rounded btn-lg" do %>
           <i class="bi bi-trash3-fill"></i>
           <span>Delete</span>
         <% end %>

--- a/app/views/users/billing_details/show.html.erb
+++ b/app/views/users/billing_details/show.html.erb
@@ -7,7 +7,7 @@
           <span>Back to Users</span>
         <% end %>
 
-        <%= button_to @user, method: :delete, class: "btn btn-danger btn-rounded btn-lg" do %>
+        <%= button_to @user, method: :delete,  data: { turbo: false },class: "btn btn-danger btn-rounded btn-lg" do %>
           <i class="bi bi-trash3-fill"></i>
           <span>Delete</span>
         <% end %>

--- a/app/views/users/destroy.turbo_stream.erb
+++ b/app/views/users/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove "row_user_#{@user.id}" %>

--- a/app/views/users/occupations/show.html.erb
+++ b/app/views/users/occupations/show.html.erb
@@ -7,7 +7,7 @@
           <span>Back to Users</span>
         <% end %>
 
-        <%= button_to @user, method: :delete, class: "btn btn-danger btn-rounded btn-lg" do %>
+        <%= button_to @user, method: :delete,  data: { turbo: false },class: "btn btn-danger btn-rounded btn-lg" do %>
           <i class="bi bi-trash3-fill"></i>
           <span>Delete</span>
         <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
           <span>Back to Users</span>
         <% end %>
 
-        <%= button_to @user, method: :delete,  data: { turbo: false }, class: "btn btn-danger btn-rounded btn-lg" do %>
+        <%= button_to @user, method: :delete, data: { turbo: false }, class: "btn btn-danger btn-rounded btn-lg" do %>
           <i class="bi bi-trash3-fill"></i>
           <span>Delete</span>
         <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
           <span>Back to Users</span>
         <% end %>
 
-        <%= button_to @user, method: :delete, class: "btn btn-danger btn-rounded btn-lg" do %>
+        <%= button_to @user, method: :delete,  data: { turbo: false }, class: "btn btn-danger btn-rounded btn-lg" do %>
           <i class="bi bi-trash3-fill"></i>
           <span>Delete</span>
         <% end %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,9 +76,33 @@ describe User do
   end
 
   describe "self.by_age" do
-    context "when user age in range" do
+    context "when user age in range and both range ends present" do
       it "returns a relation including record" do
         expect(described_class.by_age(from: 30, to: 60).pluck(:id)).to include(user.id)
+      end
+    end
+
+    context "when user age in range and from not given" do
+      it "returns a relation including record" do
+        expect(described_class.by_age(to: 60).pluck(:id)).to include(user.id)
+      end
+    end
+
+    context "when user age in range and to not given" do
+      it "returns a relation including record" do
+        expect(described_class.by_age(from: 30).pluck(:id)).to include(user.id)
+      end
+    end
+
+    context "when user age in range and from blank" do
+      it "returns a relation including record" do
+        expect(described_class.by_age(from: "", to: 60).pluck(:id)).to include(user.id)
+      end
+    end
+
+    context "when user age in range and to blank" do
+      it "returns a relation including record" do
+        expect(described_class.by_age(from: 30, to: "").pluck(:id)).to include(user.id)
       end
     end
 


### PR DESCRIPTION
This PR solves 2 bugs from the users index page:
- All search filters were cleaned whenever a user was destroyed. Here this issue is solved using a turbo stream response, so only a single row gets removed from the html
- In the age filter, if `from` or `to` were completed with an empty string, the `by_age` would return an empty relation

Additional changes:
- In the show pages, the "Delete" buttons explicitly use `data-turbo: false` to redirect to the index using html
- Added links to the user page to both the user name and the image in the user row